### PR TITLE
Update matroska.c

### DIFF
--- a/libavformat/matroska.c
+++ b/libavformat/matroska.c
@@ -75,6 +75,10 @@ const CodecTags ff_mkv_codec_tags[]={
     {"S_DVBSUB"         , AV_CODEC_ID_DVB_SUBTITLE},
     {"S_HDMV/PGS"       , AV_CODEC_ID_HDMV_PGS_SUBTITLE},
     {"S_HDMV/TEXTST"    , AV_CODEC_ID_HDMV_TEXT_SUBTITLE},
+    {"S_TEXT/USF"       , AV_CODEC_ID_USF},
+    {"S_TEXT/WEBVTT"    , AV_CODEC_ID_WEBVTT},
+    {"S_IMAGE/BMP"      , AV_CODEC_ID_BMP},
+    {"S_KATE"           , AV_CODEC_ID_KATE},
 
     {"V_DIRAC"          , AV_CODEC_ID_DIRAC},
     {"V_MJPEG"          , AV_CODEC_ID_MJPEG},


### PR DESCRIPTION
https://github.com/Matroska-Org/matroska-specification/blob/a2de2b67338fc6f5f64d58e0a65df88850eaca76/codec_specs.md#subtitle-codec-mappings

Add USF, WEBVTT, BMP and KATE to the subtitles list.

**Note**: From contributing.md :
> Committing changes to a git clone, for example on github.com or gitorious.org. And asking us to merge these changes.

So i hope i understood correctly ?